### PR TITLE
Adding replace to fix dial tcp/503 errors with this dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,5 +35,5 @@ replace (
 	github.com/opencontrol/compliance-masonry/models => ./vendor/github.com/opencontrol/fedramp-templater/vendor/github.com/opencontrol/compliance-masonry/models
 	github.com/opencontrol/fedramp-templater => ./vendor/github.com/opencontrol/fedramp-templater
 	gopkg.in/fatih/set.v0 => ./vendor/github.com/opencontrol/fedramp-templater/vendor/github.com/opencontrol/compliance-masonry/vendor/gopkg.in/fatih/set.v0
-
+	vbom.ml/util => github.com/fvbommel/util v0.0.0-20180919145318-efcd4e0f9787
 )


### PR DESCRIPTION
When trying to setup the dev build - I kept hitting this error:

```
go: github.com/opencontrol/compliance-masonry/models@v0.0.0-00010101000000-000000000000 requires
	vbom.ml/util@v0.0.0-20180919145318-efcd4e0f9787: unrecognized import path "vbom.ml/util": https fetch: Get "https://vbom.ml/util?go-get=1": dial tcp: lookup vbom.ml on 192.168.86.1:53: no such host
Error: error building at STEP "RUN go get -u -v github.com/RedHatGov/ocdb": error while running runtime: exit status 1
```

Looks like something is off about that vbom.ml address. Found a similar issue [online](https://github.com/fromanirh/performance-addon-operators/commit/e94312e563a3323e5ea8e49b86c1ffa80d0330f7) that was fixed by adding the replace path.