### PR TITLE
Get a rid of dependency on docker hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This is a multi-stage Dockerfile and requires >= Docker 17.05
 # https://docs.docker.com/engine/userguide/eng-image/multistage-build/
-FROM gobuffalo/buffalo:v0.16.16 as builder
+FROM quay.io/slukasik/buffalo-builder as builder
 
 RUN mkdir -p $GOPATH/src/github.com/RedHatGov/ocdb
 WORKDIR $GOPATH/src/github.com/RedHatGov/ocdb


### PR DESCRIPTION
This relates to the fact that docker hub stopped working in quay.

This is rather quick and dirty plug to get back to buildable state properly by
migrating to fedora.

Addressing:
Could not pull base image: API error (500): toomanyrequests: You have reached
your pull rate limit. You may increase the limit by authenticating and
upgrading: https://www.docker.com/increase-rate-limit