### PR TITLE
Use centos registry to overstep dockerhub pull rate limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN mkdir -p /var/tmp/ocdb
 WORKDIR /var/tmp/ocdb
 RUN git clone --depth 1 https://github.com/ComplianceAsCode/oscal ComplianceAsCode.oscal
 
-FROM centos:8
+FROM registry.centos.org/centos:8
 
 WORKDIR /bin/
 COPY --from=builder /bin/app .


### PR DESCRIPTION
Addressing:
```
A build step failed: toomanyrequests: You have reached your pull rate limit. You
may increase the limit by authenticating and upgrading:
https://www.docker.com/increase-rate-limit
```