### PR TITLE
Fedramp docx rewrite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN buffalo build --ldflags '-linkmode external -extldflags "-static -lz -llzma 
 RUN mkdir -p /var/tmp/ocdb
 WORKDIR /var/tmp/ocdb
 RUN git clone --depth 1 https://github.com/ComplianceAsCode/oscal ComplianceAsCode.oscal
+RUN cd ComplianceAsCode.oscal && PATH=$GOPATH:$PATH make docx
 
 FROM registry.centos.org/centos:8
 

--- a/pkg/cac_oscal/acquire.go
+++ b/pkg/cac_oscal/acquire.go
@@ -11,7 +11,7 @@ var mux sync.Mutex
 
 const (
 	gitCache  = "/var/tmp/ocdb/ComplianceAsCode.oscal"
-	docxCache = "/var/tmp/ocdb/docx_cache"
+	docxCache = gitCache + "/docx"
 )
 
 // Refresh function refreshes masonry data

--- a/pkg/cac_oscal/fedramp.go
+++ b/pkg/cac_oscal/fedramp.go
@@ -36,7 +36,7 @@ func buildFedrampDocx(componentId, level string) error {
 }
 
 func fedrampDocxPath(componentId, level string) string {
-	return fmt.Sprintf("%s/FedRAMP-%s-%s.docx", docxCache, level, componentId)
+	return fmt.Sprintf("%s/%s-fedramp-%s.docx", docxCache, componentId, level)
 }
 
 func fileNewerThan(a, b string) bool {

--- a/pkg/cac_oscal/fedramp.go
+++ b/pkg/cac_oscal/fedramp.go
@@ -8,7 +8,7 @@ import (
 )
 
 func FedrampDocx(componentId, level string) (io.ReadCloser, error) {
-	docxPath := fmt.Sprintf("%s/FedRAMP-%s-%s.docx", docxCache, level, componentId)
+	docxPath := fedrampDocxPath(componentId, level)
 	file, err := os.Open(docxPath)
 	if err != nil {
 		err = buildFedrampDocx(componentId, level)


### PR DESCRIPTION
Use docx files as build by ComplianceAsCode/oscal project. Do not duplicate build logic inside ocdb.